### PR TITLE
Update Action.scala

### DIFF
--- a/src/main/scala/io/coderunner/shrinkwrap/Action.scala
+++ b/src/main/scala/io/coderunner/shrinkwrap/Action.scala
@@ -36,7 +36,7 @@ case class ShrinkAction() extends Action {
 // Uses exiftool to copy file modification data from the original file to the transcode
 case class RecoverFileMetadata() extends Action {
   override def action(sf: ShrinkWrapFile, config: Config): String = {
-    raw"""exiftool -tagsfromfile "${sf.file.getAbsolutePath}" -extractEmbedded -all:all \
+    raw"""exiftool -tagsfromfile "${sf.file.getAbsolutePath}" -extractEmbedded "-all:all>all:all" \
        -"*gps*" -time:all --FileAccessDate --FileInodeChangeDate -FileModifyDate \
        -ext ${config.outputExtension} -overwrite_original "${sf.transcodedFile.getAbsolutePath}""""
   }


### PR DESCRIPTION
Not all metadata get actually copied. Based on the forum below, it's advisable to use "-all:all>all:all"  switch for exiftool in order to copy all metadata. 

https://video.stackexchange.com/questions/23741/how-to-prevent-ffmpeg-from-dropping-metadata